### PR TITLE
Option to pass a custom hash string

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,4 @@ var assetTree = assetRev(tree, {
   - `fingerprintExclude` - Default: `[]` - An array of strings. If a filename contains any item in the exclude array, it will not be fingerprinted.
   - `replaceExtensions` - Default: `['html', 'css']` - The file types to replace source code with new checksum file names.
   - `prependPath` - Default: `''` - A string to prepend to all of the assets. Useful for CDN urls like `https://subdomain.cloudfront.net/`
+  - `customHash` - Default: none - If defined, will be appended to filename instead of a md5 checksum.

--- a/lib/asset-rev.js
+++ b/lib/asset-rev.js
@@ -10,12 +10,14 @@ function AssetRev(inputTree, options) {
 
   this.assetMap = {};
   this.inputTree = inputTree;
+  this.customHash = options.customHash;
   this.fingerprintExtensions = options.fingerprintExtensions || ['js', 'css', 'png'];
   this.replaceExtensions = options.replaceExtensions || ['html', 'css'];
   this.description = options.description;
 
   var fingerprintTree = Fingerprint(inputTree, {
     assetMap: this.assetMap,
+    customHash: this.customHash,
     extensions: this.fingerprintExtensions,
     exclude: options.fingerprintExclude || [],
     description: options.description

--- a/lib/fingerprint.js
+++ b/lib/fingerprint.js
@@ -13,6 +13,7 @@ function Fingerprint(inputTree, options) {
 
   this.inputTree = inputTree;
   this.assetMap = options.assetMap || {};
+  this.customHash = options.customHash;
   this.extensions = options.extensions || [];
   this.exclude = options.exclude || [];
   this.description = options.description;
@@ -45,13 +46,18 @@ Fingerprint.prototype.getDestFilePath = function (relativePath) {
   if (Filter.prototype.getDestFilePath.apply(this, arguments)) {
     var tmpPath = path.join(this.inputTree.tmpDestDir, relativePath);
     var file = fs.readFileSync(tmpPath, { encoding: 'utf8' });
+    var hash;
 
-    var md5 = crypto.createHash('md5');
-    md5.update(file);
-    var hex = md5.digest('hex');
+    if (this.customHash) {
+      hash = this.customHash;
+    } else {
+      var md5 = crypto.createHash('md5');
+      md5.update(file);
+      hash = md5.digest('hex');
+    }
 
     var ext = path.extname(relativePath);
-    var newPath = relativePath.replace(ext, '-' + hex + ext);
+    var newPath = relativePath.replace(ext, '-' + hash + ext);
     this.assetMap[relativePath] = newPath;
 
     return newPath;


### PR DESCRIPTION
If you specify the `customHash` option, it will be used instead of the MD5 digest for appending to filenames. So passing “my-hash” produces `assets/vendor-my-hash.js` instead of `assets/vendor-4e4d543cde3c8a73d4723711eca0796c.js`.

My use case for this is that elsewhere in my app I have a python web server serving up the entry point (`index.html`) for an ember-cli app, and there's some other stuff in there that prevents me from using the ember-cli generated `index.html`. I need an easy way in that template to know the names of the fingerprinted files. In the past I've used git commit SHAs as fingerprints (they are helpful in debugging production deploys too) which is what I would do with a custom hash option.

Let me know what you think.
