### PR TITLE
Adds option to generate Sprockets manifest.json for Rails.

### DIFF
--- a/lib/asset-rev.js
+++ b/lib/asset-rev.js
@@ -20,6 +20,7 @@ function AssetRev(inputTree, options) {
     customHash: this.customHash,
     extensions: this.fingerprintExtensions,
     exclude: options.fingerprintExclude || [],
+    generateRailsManifest: options.generateRailsManifest
     description: options.description
   });
 

--- a/lib/fingerprint.js
+++ b/lib/fingerprint.js
@@ -17,6 +17,7 @@ function Fingerprint(inputTree, options) {
   this.extensions = options.extensions || [];
   this.exclude = options.exclude || [];
   this.description = options.description;
+  this.generateRailsManifest = options.generateRailsManifest;
 }
 
 Fingerprint.prototype = Object.create(Filter.prototype);
@@ -64,6 +65,42 @@ Fingerprint.prototype.getDestFilePath = function (relativePath) {
   }
 
   return null;
+};
+
+Fingerprint.prototype.writeRailsManifest = function(destDir) {
+    var assetRegex = /^assets\//,
+        digestRegex = /-([0-9a-f]+)\.\w+$/,
+        assetMap = {},
+        files = {};
+
+    for (var key in this.assetMap) {
+      if (assetRegex.test(key)) {
+        var fingerprintedPath = this.assetMap[key],
+            assetlessKey = key.replace(assetRegex, ''),
+            assetlessFingerprintedPath = fingerprintedPath.replace(assetRegex, ''),
+            stats = fs.statSync(destDir + '/' + fingerprintedPath);
+
+        files[assetlessFingerprintedPath] = {
+          mtime: stats.mtime,
+          logical_path: assetlessKey,
+          digest: fingerprintedPath.match(digestRegex)[1],
+          size: stats.size
+        }
+        assetMap[assetlessKey] = assetlessFingerprintedPath;
+      }
+    }
+    var assets = { assets: assetMap, files:  files };
+    fs.writeFileSync(destDir + '/assets/manifest.json', JSON.stringify(assets));
+};
+
+Fingerprint.prototype.write = function(readTree, destDir) {
+  var self = this;
+
+  return Filter.prototype.write.apply(this, arguments).then(function() {
+    if (!!self.generateRailsManifest) {
+      self.writeRailsManifest(destDir);
+    }
+  });
 };
 
 module.exports = Fingerprint;


### PR DESCRIPTION
When specifying

``` js
fingerprint: {
  generateRailsManifest: true
}
```

Fingerprint will generate a Sprockets compatible manifest.json for rails
which will allow rails to auto-resolve fingerprinted assets.

Once this is added to asset-rev, ember-cli will need to be modified as
well to take advantage of this
