### PR TITLE
Make into an ember-addon.

### DIFF
--- a/lib/ember-cli-main.js
+++ b/lib/ember-cli-main.js
@@ -1,0 +1,42 @@
+var path = require('path');
+var fs   = require('fs');
+
+var assetRev = require('./asset-rev');
+
+function EmberCLIAssetRev(project) {
+  this.project = project;
+  this.name    = 'broccoli-asset-rev';
+}
+
+EmberCLIAssetRev.prototype.initializeOptions = function() {
+  var defaultOptions = {
+    enabled: this.app.env === 'production',
+    exclude: [],
+    extensions: ['js', 'css', 'png', 'jpg', 'gif'],
+    prepend: '',
+    replaceExtensions: ['html', 'css', 'js']
+  }
+
+  this.options = this.app.options.fingerprint || {};
+
+  for (var option in defaultOptions) {
+    if (!this.options.hasOwnProperty(option)) {
+      this.options[option] = defaultOptions[option];
+    }
+  }
+};
+
+EmberCLIAssetRev.prototype.postprocessTree = function (type, tree) {
+  if (type === 'all' && this.options.enabled) {
+    tree = assetRev(tree, this.options);
+  }
+
+  return tree;
+};
+
+EmberCLIAssetRev.prototype.included = function (app) {
+  this.app = app;
+  this.initializeOptions();
+};
+
+module.exports = EmberCLIAssetRev;

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.9",
   "description": "broccoli asset revisions (fingerprint)",
   "main": "lib/asset-rev.js",
+  "ember-addon-main": "lib/ember-cli-main.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
@@ -17,7 +18,8 @@
     "rev",
     "fingerprint",
     "cloudfront",
-    "cdn"
+    "cdn",
+    "ember-addon"
   ],
   "author": "Rick Harrison",
   "license": "MIT",


### PR DESCRIPTION
This PR turns `broccoli-asset-rev` into an Ember CLI addon.  It is using the API defined in https://github.com/stefanpenner/ember-cli/pull/1214 (which is actually pending a new version of `broccoli-asset-rev` that implements this).

That PR makes a `postprocessTree` hook available to all addons. This provides what is needed for `broccoli-asset-rev`, but also allows other addons to hook into the process (it even allows ordering `before` or `after` another addon).
