### PR TITLE
Share settings with app.

### DIFF
--- a/lib/ember-cli-main.js
+++ b/lib/ember-cli-main.js
@@ -17,7 +17,7 @@ EmberCLIAssetRev.prototype.initializeOptions = function() {
     replaceExtensions: ['html', 'css', 'js']
   }
 
-  this.options = this.app.options.fingerprint || {};
+  this.options = this.app.options.fingerprint = this.app.options.fingerprint || {};
 
   for (var option in defaultOptions) {
     if (!this.options.hasOwnProperty(option)) {


### PR DESCRIPTION
This allows Ember CLI to augment the settings if `broccoli-asset-rev` is present (since in the addon world Ember CLI itself is not directly aware of `broccoli-asset-rev`).

Specifically, we need to add `testem.js` to `excludes` if `broccoli-asset-rev` is present. This will allow tests to run against the production builds.
