### PR TITLE
Use `replaceExtensions` option properly.

### DIFF
--- a/lib/use-rev.js
+++ b/lib/use-rev.js
@@ -1,3 +1,4 @@
+var path   = require('path');
 var Filter = require('broccoli-filter');
 
 function UseRev(inputTree, options) {
@@ -9,7 +10,7 @@ function UseRev(inputTree, options) {
 
   this.inputTree = inputTree;
   this.assetMap = options.assetMap || {};
-  this.extensions = options.replaceExtensions || [];
+  this.replaceExtensions = options.replaceExtensions || [];
   this.prepend = options.prepend || '';
   this.description = options.description;
 }
@@ -17,8 +18,12 @@ function UseRev(inputTree, options) {
 UseRev.prototype = Object.create(Filter.prototype);
 UseRev.prototype.constructor = UseRev;
 
-UseRev.prototype.processString = function (string) {
+UseRev.prototype.processString = function (string, relativePath) {
   var newString = string;
+  var extension = path.extname(relativePath).slice(1); // get the extension without leading period
+  if (this.replaceExtensions.indexOf(extension) === -1) {
+    return string;
+  }
 
   /*
    * Replace all of the assets with their new fingerprint name


### PR DESCRIPTION
Prior to this change, the `replaceExtensions` list was never used, and we attempted to match all files.
