### PR TITLE
Revert "Use `replaceExtensions` option properly."

### DIFF
--- a/lib/use-rev.js
+++ b/lib/use-rev.js
@@ -1,4 +1,3 @@
-var path   = require('path');
 var Filter = require('broccoli-filter');
 
 function UseRev(inputTree, options) {
@@ -10,7 +9,7 @@ function UseRev(inputTree, options) {
 
   this.inputTree = inputTree;
   this.assetMap = options.assetMap || {};
-  this.replaceExtensions = options.replaceExtensions || [];
+  this.extensions = options.replaceExtensions || [];
   this.prepend = options.prepend || '';
   this.description = options.description;
 }
@@ -18,12 +17,8 @@ function UseRev(inputTree, options) {
 UseRev.prototype = Object.create(Filter.prototype);
 UseRev.prototype.constructor = UseRev;
 
-UseRev.prototype.processString = function (string, relativePath) {
+UseRev.prototype.processString = function (string) {
   var newString = string;
-  var extension = path.extname(relativePath).slice(1); // get the extension without leading period
-  if (this.replaceExtensions.indexOf(extension) === -1) {
-    return string;
-  }
 
   /*
    * Replace all of the assets with their new fingerprint name


### PR DESCRIPTION
This reverts commit c50fb4a78f82ba813c85eef4df14d1bdfd11d5e3.

Apparently, I should have looked further, sorry for the wasted effort.

`this.extensions` is used by broccoli-filter internally and only calls `processString` when the files extension matches.
