### PR TITLE
Implement treeFor method

### DIFF
--- a/lib/ember-cli-main.js
+++ b/lib/ember-cli-main.js
@@ -39,4 +39,6 @@ EmberCLIAssetRev.prototype.included = function (app) {
   this.initializeOptions();
 };
 
+EmberCLIAssetRev.prototype.treeFor = function() {};
+
 module.exports = EmberCLIAssetRev;


### PR DESCRIPTION
This is currently breaking builds until a new release of ember-cli. Was just [fixed recently](https://github.com/stefanpenner/ember-cli/blame/f3b117527641fc123b48a7ff458a68fe6ba0bb45/lib/broccoli/ember-app.js#L122)

```
> ember test

version: 0.0.37
BuildingBuilding...
The `EmberCLIAssetRev` addon must implement the `treeFor` hook.Error: The `EmberCLIAssetRev` addon must implement the `treeFor` hook.
at EmberApp.<anonymous> (/home/rof/src/bitbucket.org/poetic/eventassist-ember-cordova/node_modules/ember-cli/lib/broccoli/ember-app.js:122:13)
```
