### PR TITLE
Correctly generates rails 4 manifest

### DIFF
--- a/lib/fingerprint.js
+++ b/lib/fingerprint.js
@@ -90,7 +90,12 @@ Fingerprint.prototype.writeRailsManifest = function(destDir) {
       }
     }
     var assets = { assets: assetMap, files:  files };
-    fs.writeFileSync(destDir + '/assets/manifest.json', JSON.stringify(assets));
+    var contents = JSON.stringify(assets);
+    var hash = '';
+    var md5 = crypto.createHash('md5');
+    md5.update(contents);
+    hash = md5.digest('hex');
+    fs.writeFileSync(destDir + '/assets/manifest-' + hash + '.json', contents);
 };
 
 Fingerprint.prototype.write = function(readTree, destDir) {


### PR DESCRIPTION
Heroku expects a hash in the filename, Heroku will try to precomile the assets, and this causes bad assets to be used
