### PR TITLE
ember-addon-main update

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "0.0.16",
   "description": "broccoli asset revisions (fingerprint)",
   "main": "lib/asset-rev.js",
-  "ember-addon-main": "lib/ember-cli-main.js",
+  "ember-addon": {
+    "main": "lib/ember-cli-main.js"
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
The ember-addon-main definition being used is now deprecated in ember-cli master and will be in the next release so I've updated it to conform to the newer spec.
