### PR TITLE
Fingerprint sourcemap files by default

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ module.exports = {
     var defaultOptions = {
       enabled: this.app.env === 'production',
       exclude: [],
-      extensions: ['js', 'css', 'png', 'jpg', 'gif'],
+      extensions: ['js', 'css', 'png', 'jpg', 'gif', 'map'],
       prepend: '',
       replaceExtensions: ['html', 'css', 'js']
     }


### PR DESCRIPTION
I would like to propose adding sourcemap files to the default list of fingerprinted assets. I have already landed a [PR in broccoli-asset-rewrite](https://github.com/rickharrison/broccoli-asset-rewrite/pull/8) that makes their references get rewritten correctly.
