### PR TITLE
options.exportAssetMap writes assets/assetMap-HASH.js

### DIFF
--- a/lib/asset-rev.js
+++ b/lib/asset-rev.js
@@ -15,9 +15,16 @@ function AssetRev(inputTree, options) {
   this.replaceExtensions = options.replaceExtensions || ['html', 'css', 'js'];
   this.exclude = options.exclude || [];
   this.generateAssetMap = options.generateAssetMap;
+  this.exportAssetMap = options.exportAssetMap;
   this.generateRailsManifest = options.generateRailsManifest;
   this.prepend = options.prepend || '';
   this.description = options.description;
+
+  if (this.exportAssetMap) {
+    this.replaceExtensions = this.replaceExtensions.filter(function (item) {
+      return item !== 'js';
+    });
+  }
 
   var fingerprintTree = Fingerprint(inputTree, this);
 

--- a/lib/fingerprint.js
+++ b/lib/fingerprint.js
@@ -91,11 +91,11 @@ Fingerprint.prototype.writeAssetMap = function (destDir) {
     fs.mkdirSync(destDir + '/assets');
   }
 
-  fs.writeFileSync(destDir + '/assets/assetMap.json', JSON.stringify(toWrite));
+  fs.writeFileSync(destDir + '/assets/asset-map.json', JSON.stringify(toWrite));
 };
 
-// Write assetMap-HASH.js which exports window.ASSET_MAP.
-// @usage <script src="/assets/assetMap.js"></script> in html source
+// Write asset-map-HASH.js which exports window.ASSET_MAP.
+// @usage <script src="/assets/asset-map.js"></script> in html source
 Fingerprint.prototype.writeAssetMapJs = function (destDir) {
   var toWrite = {
     assets: this.assetMap,
@@ -107,10 +107,10 @@ Fingerprint.prototype.writeAssetMapJs = function (destDir) {
 
   // Add prefix to content to export window.ASSET_MAP
   var contents = new Buffer('window.ASSET_MAP = ' + JSON.stringify(toWrite) + ';');
-  var fileName = 'assetMap-' + this.hashFn(contents) + '.js';
+  var fileName = 'asset-map-' + this.hashFn(contents) + '.js';
 
   // Add assetMap.js to assetMap to enable asset rewrite
-  this.assetMap['assets/assetMap.js'] = 'assets/' + fileName;
+  this.assetMap['assets/asset-map.js'] = 'assets/' + fileName;
 
   fs.writeFileSync(destDir + '/assets/' + fileName, contents);
 };
@@ -133,7 +133,7 @@ Fingerprint.prototype.writeRailsManifest = function(destDir) {
           logical_path: assetlessKey,
           digest: fingerprintedPath.match(digestRegex)[1],
           size: stats.size
-        }
+        };
         assetMap[assetlessKey] = assetlessFingerprintedPath;
       }
     }

--- a/lib/fingerprint.js
+++ b/lib/fingerprint.js
@@ -17,6 +17,7 @@ function Fingerprint(inputTree, options) {
   this.exclude = options.exclude || [];
   this.description = options.description;
   this.generateAssetMap = options.generateAssetMap;
+  this.exportAssetMap = options.exportAssetMap;
   this.generateRailsManifest = options.generateRailsManifest;
   this.prepend = options.prepend;
 
@@ -93,6 +94,27 @@ Fingerprint.prototype.writeAssetMap = function (destDir) {
   fs.writeFileSync(destDir + '/assets/assetMap.json', JSON.stringify(toWrite));
 };
 
+// Write assetMap-HASH.js which exports window.ASSET_MAP.
+// @usage <script src="/assets/assetMap.js"></script> in html source
+Fingerprint.prototype.writeAssetMapJs = function (destDir) {
+  var toWrite = {
+    assets: this.assetMap,
+    prepend: this.prepend
+  };
+  if (!fs.existsSync(destDir + '/assets')) {
+    fs.mkdirSync(destDir + '/assets');
+  }
+
+  // Add prefix to content to export window.ASSET_MAP
+  var contents = new Buffer('window.ASSET_MAP = ' + JSON.stringify(toWrite) + ';');
+  var fileName = 'assetMap-' + this.hashFn(contents) + '.js';
+
+  // Add assetMap.js to assetMap to enable asset rewrite
+  this.assetMap['assets/assetMap.js'] = 'assets/' + fileName;
+
+  fs.writeFileSync(destDir + '/assets/' + fileName, contents);
+};
+
 Fingerprint.prototype.writeRailsManifest = function(destDir) {
     var assetRegex = /^assets\//,
         digestRegex = /-([0-9a-f]+)\.\w+$/,
@@ -127,6 +149,10 @@ Fingerprint.prototype.write = function(readTree, destDir) {
   return Filter.prototype.write.apply(this, arguments).then(function() {
     if (!!self.generateAssetMap) {
       self.writeAssetMap(destDir);
+    }
+
+    if (!!self.exportAssetMap) {
+      self.writeAssetMapJs(destDir);
     }
 
     if (!!self.generateRailsManifest) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "broccoli-asset-rev",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "broccoli asset revisions (fingerprint)",
   "main": "lib/asset-rev.js",
   "scripts": {


### PR DESCRIPTION
and adds assetMap.js to asset map, for asset rewrite
usage: `<script src="assets/assetMap.js">` in html source

This allows client side JS to use versioned assets via `window.ASSET_MAP`.