### PR TITLE
Ensure ember-cli knows the proper location of the addon entry point.

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "2.0.1",
   "description": "broccoli asset revisions (fingerprint)",
   "main": "lib/asset-rev.js",
+  "ember-addon": {
+    "main": "index.js"
+  },
   "scripts": {
     "test": "mocha tests"
   },


### PR DESCRIPTION
Ember CLI previously used `index.js` as a fallback path, but it should have checked the `main` property first (which is being added in https://github.com/ember-cli/ember-cli/pull/3545). However, if `main` is used with `broccoli-asset-rev` we do not get the right entry script (we would get `lib/asset-rev.js` instead of `index.js`).

This fixes that issue by defining the custom `ember-addon.main` entry point script.  This is backwards compatible.