### PR TITLE
Consistent Hashing

### DIFF
--- a/lib/fingerprint.js
+++ b/lib/fingerprint.js
@@ -68,7 +68,7 @@ Fingerprint.prototype.getDestFilePath = function (relativePath) {
     }
 
     var tmpPath = path.join(this._srcDir, relativePath);
-    var file = fs.readFileSync(tmpPath, { encoding: 'utf8' });
+    var file = fs.readFileSync(tmpPath, { encoding: null });
     var hash;
 
     if (this.customHash) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "broccoli-asset-rev",
-  "version": "2.1.0",
+  "version": "2.1.0-LUXUS",
   "description": "broccoli asset revisions (fingerprint)",
   "main": "lib/asset-rev.js",
   "ember-addon": {


### PR DESCRIPTION
Specifying an encoding of "UTF8" to fs.readFileSync(...) is not desired.  Hashing the String representation of a binary file will never be consistent.  See my comments in the commit.