### PR TITLE
Add support for common `annotation` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ var assetNode = new AssetRev(node, {
 	}
 }
 ```
- - `ignore` - Default: `[]` - An array of strings.  If a filename contains any item in the ignore array, the contents of the file will not be processed for fingerprinting.
+  - `ignore` - Default: `[]` - An array of strings.  If a filename contains any item in the ignore array, the contents of the file will not be processed for fingerprinting.
+  - `annotation` - Default: null. A human-readable description for this plugin instance.
 
 ## Ember CLI addon usage
 

--- a/lib/fingerprint.js
+++ b/lib/fingerprint.js
@@ -17,12 +17,13 @@ function Fingerprint(inputNode, options) {
   options = options || {};
 
   Filter.call(this, inputNode, {
-    extensions: options.extensions || []
+    extensions: options.extensions || [],
+    // We should drop support for `description` in the next major release
+    annotation: options.description || options.annotation
   })
 
   this.assetMap = options.assetMap || {};
   this.exclude = options.exclude || [];
-  this.description = options.description;
   this.generateAssetMap = options.generateAssetMap;
   this.generateRailsManifest = options.generateRailsManifest;
   this.prepend = options.prepend;

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "homepage": "https://github.com/rickharrison/broccoli-asset-rev",
   "dependencies": {
     "broccoli-asset-rewrite": "^1.0.9",
-    "broccoli-filter": "~0.2.0",
+    "broccoli-filter": "^1.1.0",
     "json-stable-stringify": "^1.0.0",
     "rsvp": "~3.0.6"
   },


### PR DESCRIPTION
Also fix handling of `description` option after recent broccoli-filter update.
Filter (via Plugin) automatically sets `this.description` in .read
compatibility mode, so we don't need to set it.