### PR TITLE
Enable fingerprinting of the asset map.

### DIFF
--- a/lib/asset-rev.js
+++ b/lib/asset-rev.js
@@ -14,6 +14,7 @@ function AssetRev(inputTree, options) {
   this.extensions = options.extensions || ['js', 'css', 'png', 'jpg', 'gif', 'map'];
   this.replaceExtensions = options.replaceExtensions || ['html', 'css', 'js'];
   this.exclude = options.exclude || [];
+  this.fingerprintAssetMap = options.fingerprintAssetMap || false;
   this.generateAssetMap = options.generateAssetMap;
   this.generateRailsManifest = options.generateRailsManifest;
   this.prepend = options.prepend || '';

--- a/lib/fingerprint.js
+++ b/lib/fingerprint.js
@@ -24,6 +24,7 @@ function Fingerprint(inputNode, options) {
 
   this.assetMap = options.assetMap || {};
   this.exclude = options.exclude || [];
+  this.fingerprintAssetMap = options.fingerprintAssetMap || false;
   this.generateAssetMap = options.generateAssetMap;
   this.generateRailsManifest = options.generateRailsManifest;
   this.prepend = options.prepend;
@@ -96,11 +97,15 @@ Fingerprint.prototype.writeAssetMap = function (destDir) {
     prepend: this.prepend
   };
 
+  var contents = new Buffer(stringify(toWrite));
+  var fileName = this.fingerprintAssetMap ? 'assetMap-' + this.hashFn(contents) + '.json' : 'assetMap.json';
+
   if (!fs.existsSync(destDir + '/assets')) {
     fs.mkdirSync(destDir + '/assets');
   }
 
-  fs.writeFileSync(destDir + '/assets/assetMap.json', stringify(toWrite));
+  fs.writeFileSync(destDir + '/assets/' + fileName, contents);
+  this.assetMap['assets/assetMap.json'] = 'assets/' + fileName;
 };
 
 Fingerprint.prototype.findExistingManifest = function(destDir) {

--- a/tests/filter-tests.js
+++ b/tests/filter-tests.js
@@ -80,7 +80,7 @@ describe('broccoli-asset-rev', function() {
     builder = new broccoli.Builder(node);
     return builder.build().then(function(graph) {
       var actualFiles = walkSync(graph.directory);
-      var pathPresent = confirmPathPresent(actualFiles, /manifest-[0-9a-f]{32}.json/);
+      var pathPresent = confirmPathPresent(actualFiles, /manifest-[0-9a-f]{32}\.json/);
 
       assert(pathPresent, "manifest file not found");
     });
@@ -99,9 +99,46 @@ describe('broccoli-asset-rev', function() {
     builder = new broccoli.Builder(node);
     return builder.build().then(function(graph) {
       var actualFiles = walkSync(graph.directory);
-      var pathPresent = confirmPathPresent(actualFiles, /manifest.json/);
+      var pathPresent = confirmPathPresent(actualFiles, /manifest\.json/);
 
       assert(pathPresent, "manifest file not found");
+    });
+  });
+
+  it('generates an asset map if requested', function () {
+    var sourcePath = 'tests/fixtures/basic';
+
+    var node = new AssetRev(sourcePath + '/input', {
+      extensions: ['js', 'css', 'png', 'jpg', 'gif'],
+      generateAssetMap: true,
+      replaceExtensions: ['html', 'js', 'css']
+    });
+
+    builder = new broccoli.Builder(node);
+    return builder.build().then(function(graph) {
+      var actualFiles = walkSync(graph.directory);
+      var pathPresent = confirmPathPresent(actualFiles, /assetMap\.json/);
+
+      assert(pathPresent, "asset map file not found");
+    });
+  });
+
+  it("fingerprints the asset map if requested", function () {
+    var sourcePath = 'tests/fixtures/basic';
+
+    var node = new AssetRev(sourcePath + '/input', {
+      extensions: ['js', 'css', 'png', 'jpg', 'gif'],
+      fingerprintAssetMap: true,
+      generateAssetMap: true,
+      replaceExtensions: ['html', 'js', 'css']
+    });
+
+    builder = new broccoli.Builder(node);
+    return builder.build().then(function(graph) {
+      var actualFiles = walkSync(graph.directory);
+      var pathPresent = confirmPathPresent(actualFiles, /assetMap-[0-9a-f]{32}\.json/);
+
+      assert(pathPresent, "fingerprinted asset map file not found");
     });
   });
 


### PR DESCRIPTION
First, `broccoli-filter@1.2.2` that started breaking this module. I locked the package version to fix that.

Second, like the Rails Manifest, we'd like to be able fingerprint the Asset Map. 

I'd like to use the fingerprint unless excluded pattern that `manifest.json` uses, but that breaks backwards compatibility. Accordingly, I added `fingerprintAssetMap` as an option. It defaults to `false`.

I added tests to cover the new use cases.

Can you accept this pull request?