### PR TITLE
Fix broccoli-filter breakage

### DIFF
--- a/lib/fingerprint.js
+++ b/lib/fingerprint.js
@@ -51,8 +51,6 @@ Fingerprint.prototype.canProcessFile = function (relativePath) {
 };
 
 Fingerprint.prototype.processFile = function (srcDir, destDir, relativePath) {
-  this._srcDir = srcDir;
-
   var file = fs.readFileSync(srcDir + '/' + relativePath);
   var self = this;
 
@@ -72,7 +70,7 @@ Fingerprint.prototype.getDestFilePath = function (relativePath) {
       return this.assetMap[relativePath] = destFilePath;
     }
 
-    var tmpPath = path.join(this._srcDir, relativePath);
+    var tmpPath = path.join(this.inputPaths[0], relativePath);
     var file = fs.readFileSync(tmpPath, { encoding: null });
     var hash;
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "homepage": "https://github.com/rickharrison/broccoli-asset-rev",
   "dependencies": {
     "broccoli-asset-rewrite": "^1.0.9",
-    "broccoli-filter": "^1.1.0",
+    "broccoli-filter": "^1.2.2",
     "json-stable-stringify": "^1.0.0",
     "rsvp": "~3.0.6"
   },


### PR DESCRIPTION
broccoli-asset-rev is using broccoli-filter in a bit of an unusual way, so it was affected by changes we thought would be non-breaking.

For what it's worth, I don't think it really benefits from broccoli-filter's caching functionality, so perhaps it's easier to derive this directly from [broccoli-plugin](https://github.com/broccolijs/broccoli-plugin) at some point.