### PR TITLE
Add `svg` as a default file extension

### DIFF
--- a/lib/asset-rev.js
+++ b/lib/asset-rev.js
@@ -11,7 +11,7 @@ function AssetRev(inputTree, options) {
   this.assetMap = {};
   this.inputTree = inputTree;
   this.customHash = options.customHash;
-  this.extensions = options.extensions || ['js', 'css', 'png', 'jpg', 'gif', 'map'];
+  this.extensions = options.extensions || ['js', 'css', 'png', 'jpg', 'gif', 'map', 'svg'];
   this.replaceExtensions = options.replaceExtensions || ['html', 'css', 'js'];
   this.exclude = options.exclude || [];
   this.fingerprintAssetMap = options.fingerprintAssetMap || false;


### PR DESCRIPTION
[Modern browsers][caniuse] now support `svg` as a valid [`background-image` value][background].

We should support this out of the box, without additional configuration.

[caniuse]: http://caniuse.com/#feat=svg-css
[background]: https://css-tricks.com/using-svg/