### PR TITLE
Rename exclude tests

### DIFF
--- a/tests/filter-tests.js
+++ b/tests/filter-tests.js
@@ -105,7 +105,7 @@ describe('broccoli-asset-rev', function() {
     });
   });
 
-  it('accepts a string as exclude parameter', function () {
+  it('accepts an array of strings as exclude parameter', function () {
     var sourcePath = 'tests/fixtures/exclude';
 
     var node = new AssetRev(sourcePath + '/input', {
@@ -120,7 +120,7 @@ describe('broccoli-asset-rev', function() {
     });
   });
 
-  it("accepts a glob as exclude parameter", function() {
+  it("accepts an array of globs as exclude parameter", function() {
     var sourcePath = 'tests/fixtures/exclude';
 
     var node = new AssetRev(sourcePath + '/input', {


### PR DESCRIPTION
The tests read like if there was also a string instead of only an array
supported as `exclude` parameter.