### PR TITLE
Upgrade "rsvp" version contraint

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "broccoli-filter": "^1.2.2",
     "json-stable-stringify": "^1.0.0",
     "matcher-collection": "^1.0.1",
-    "rsvp": "~3.0.6"
+    "rsvp": "^3.0.6"
   },
   "devDependencies": {
     "broccoli": "^0.13.3",


### PR DESCRIPTION
Allows "rsvp" minor releases too now, which enables NPM to deduplicate more efficiently.