### PR TITLE
broccoli-asset-rewrite@^1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "homepage": "https://github.com/rickharrison/broccoli-asset-rev",
   "dependencies": {
-    "broccoli-asset-rewrite": "^1.0.13",
+    "broccoli-asset-rewrite": "^1.1.0",
     "broccoli-filter": "^1.2.2",
     "json-stable-stringify": "^1.0.0",
     "matcher-collection": "^1.0.1",


### PR DESCRIPTION
Just realized we never bumped the dependency to take advantage of https://github.com/rickharrison/broccoli-asset-rewrite/pull/46