### PR TITLE
Make broccoli-asset-rev run before ember-asset-loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "index.js"
   ],
   "ember-addon": {
-    "main": "index.js"
+    "main": "index.js",
+    "before": "ember-asset-loader"
   },
   "scripts": {
     "test": "mocha tests",


### PR DESCRIPTION
`ember-asset-loader` generates asset lists by walking through the post-process tree, which needs `broccoli-asset-rev` to run before `ember-asset-loader` to make sure all files have been fingerprinted in production build before the asset list compilation.