### PR TITLE
Adds the option to specify files that need a third pass of UseRev

### DIFF
--- a/lib/asset-rev.js
+++ b/lib/asset-rev.js
@@ -33,12 +33,24 @@ function AssetRev(inputTree, options) {
   var assetRewrite = UseRev(fingerprintTree, this);
 
   // second pass - fingerprints replaceable source code
-  this.exclude = exclude;
+  this.exclude = exclude.slice();
+  if (options.filesForThirdPass) {
+    this.exclude = this.exclude.concat(options.filesForThirdPass);
+  }
   this.onlyHash = this.replaceExtensions;
   var fingerprintTree2 = Fingerprint(assetRewrite, this);
   var assetRewrite2 = UseRev(fingerprintTree2, this);
 
-  return new FastbootManifestRewrite(assetRewrite2, this.assetMap);
+  // Some files may need to be hashed until the third
+  // pass since they contain references to other files that are fingerprinted
+  if (options.filesForThirdPass) {
+    this.exclude = exclude;
+    this.onlyHash = options.filesForThirdPass;
+    var fingerprintTree3 = Fingerprint(assetRewrite2, this);
+    var assetRewrite3 = UseRev(fingerprintTree3, this);
+  }
+
+  return new FastbootManifestRewrite(assetRewrite3 || assetRewrite2, this.assetMap);
 }
 
 module.exports = AssetRev;


### PR DESCRIPTION
Sort-of FIXES https://github.com/rickharrison/broccoli-asset-rev/issues/29 (or more like works around it). 

For cases where you know which files have references to other files that are in the replaceExtensions (by default JS, HTML, CSS) we can explicitly add those to a new `filesForThirdPass` option. This solution works for https://github.com/MiguelMadero/ember-cli-bundle-loader/pull/32 and could likely work for others as well. 

For cases where dependencies are not well understood at configuration time, a better solution might be needed like what Nathan suggested on https://github.com/rickharrison/broccoli-asset-rev/issues/29 