### PR TITLE
add commonly used file extensions

### DIFF
--- a/lib/default-options.js
+++ b/lib/default-options.js
@@ -2,7 +2,7 @@
 module.exports = {
   assetMapPath: '',
   exclude: [],
-  extensions: ['js', 'css', 'png', 'jpg', 'gif', 'map'],
+  extensions: ['js', 'css', 'png', 'jpg', 'gif', 'svg', 'webp', 'map', 'mp4', 'webmanifest', 'json'],
   fingerprintAssetMap: false,
   prepend: '',
   railsManifestPath: '',


### PR DESCRIPTION
from https://github.com/emberjs/rfcs/pull/648 this PR adds default support for file suffixes: `svg`, `webp`, `mp4`, `webmanifest` and `json`