### PR TITLE
ensure we only endup with one assetMap when fingerprintAssetMap is true

### DIFF
--- a/lib/fingerprint.js
+++ b/lib/fingerprint.js
@@ -10,6 +10,7 @@ var Minimatch = require('minimatch').Minimatch;
 
 var MANIFEST_REGEX = /^manifest(-[0-9a-f]+)?.json$/;
 var MULTIPLE_MANIFEST_FILES = 'Multiple manifest files found. Using the first one.';
+var assetMapHash = '';
 
 function Fingerprint(inputNode, options) {
   if (!(this instanceof Fingerprint)) {
@@ -146,7 +147,8 @@ Fingerprint.prototype.writeAssetMap = function (destDir) {
   var fileNameNoHash = fileName;
 
   if (!fileName) {
-    fileName = 'assets/' + (this.fingerprintAssetMap ? 'assetMap-' + this.hashFn(contents) + '.json' : 'assetMap.json');
+    assetMapHash = assetMapHash || this.hashFn(contents);
+    fileName = 'assets/' + (this.fingerprintAssetMap ? 'assetMap-' + assetMapHash + '.json' : 'assetMap.json');
     fileNameNoHash = 'assets/assetMap.json';
   }
 


### PR DESCRIPTION
# Overview
When using the option `fingerprintAssetMap: true` you end up with two different versions of the assetMap.json by default i.e. 

`assetMapPath - Default: 'assets/assetMap-HASH.json'`

It seems `Fingerprint.prototype.writeAssetMap` gets called multiple times (2 at least) by the build process, I honestly don't know if this is normal or how to go deeper on this topic...  so for each call an assetMap.json is written with a different md5 hash, also it seems that each call is incremental, meaning it always have the first's call assets plus new ones found I guess.

Alternatively when using `fingerprintAssetMap: false` the `fileName` stays the same in each call and so it gets effectively overwritten by the last writeAssetMap execution, so this "bug" actually always exists,  its just hidden when using the default value `fingerprintAssetMap: false`.

## Patch/Fix

There's prob a better way to do this, but for now, save the assetMapHash for latter reuse, so we basically overwrite the file, like when using `fingerprintAssetMap: false`

### Related Issues
#122 
